### PR TITLE
Fix name of OCI target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v1
     with:
       input-wasm: pod_privileged_policy
-      oci-target: ghcr.io/kubewarden/policies/pod-privileged-policy
+      oci-target: ghcr.io/kubewarden/policies/pod-privileged
     
     secrets:
       workflow-pat: ${{ secrets.WORKFLOW_PAT }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pod-privileged-policy"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pod-privileged-policy"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.0
+version: 0.2.1
 name: pod-privileged-policy
 displayName: Pod Privileged Policy
 createdAt: '2022-07-19T16:04:10+02:00'
@@ -8,7 +8,7 @@ license: Apache-2.0
 homeURL: https://github.com/kubewarden/pod-privileged-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/pod-privileged:v0.2.0
+  image: ghcr.io/kubewarden/policies/pod-privileged:v0.2.1
 keywords:
 - psp
 - pod
@@ -16,7 +16,7 @@ keywords:
 - privileged
 links:
 - name: policy
-  url: https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.2.0/policy.wasm
+  url: https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.2.1/policy.wasm
 - name: source
   url: https://github.com/kubewarden/pod-privileged-policy
 provider:


### PR DESCRIPTION
ArtifactHub shows pod-privileged, but we release under
pod-privileged-policy. This results in manifest unknown error.

## Description

Go to https://artifacthub.io/packages/kubewarden/pod-privileged-policy/pod-privileged-policy?modal=install
and copy & paste command - it results with error:
```
~ kwctl pull ghcr.io/kubewarden/policies/pod-privileged:v0.2.0
Error: the policy registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.0 could not be downloaded due to error: Registry error: url https://ghcr.io/v2/kubewarden/policies/pod-privileged/manifests/v0.2.0, envelope: OCI API errors: [OCI API error: manifest unknown]
```
