### PR TITLE
Relax anyhow version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "autocfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.63"
+anyhow = "1.0"
 k8s-openapi = { version = "0.15.0", default_features = false, features = ["v1_24"] }
 kubewarden-policy-sdk = "0.6.3"
 lazy_static = "1.4"


### PR DESCRIPTION
Do not specify the patch level of `anyhow`. Also, update to latest stable release.

Supersedes https://github.com/kubewarden/pod-privileged-policy/pull/30

