### PR TITLE
Change the policy resources.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,11 +51,10 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -67,11 +66,10 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -117,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4f07471a46151c3272d2ed0e3e62ecbae9b75ff374476c9468b54cd6b20a10"
+checksum = "cb74a06b3c71b42b287a4d635dfecd2a58bb047db581a88415ea75959b7a54cc"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -147,12 +145,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,12 +153,6 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "num"
@@ -297,13 +283,13 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pod-privileged-policy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -396,14 +382,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -466,14 +453,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.2.2"
+name = "unsafe-libyaml"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]
@@ -509,12 +501,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pod-privileged-policy"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2018"
 
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0"
 k8s-openapi = { version = "0.15.0", default_features = false, features = ["v1_24"] }
-kubewarden-policy-sdk = "0.6.3"
+kubewarden-policy-sdk = "0.7.0"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ configured as privileged in their [SecurityContext](https://kubernetes.io/docs/t
 
 This policy has no configurable settings.
 
+The user is responsible to configure the policy defining the resources targeted
+by the policy. Otherwise, the policy will not be able to run. The current supported
+resources are listed in the metadata.yml file. See more information about how to
+configure a policy in the [Kubewarden documentation](https://docs.kubewarden.io/).
+
 # Examples
 
 The following Pod specification doesn't have any security context defined:

--- a/e2e.bats
+++ b/e2e.bats
@@ -22,3 +22,28 @@
   [ "$status" -eq 0 ]
   [ $(expr "$output" : '.*allowed.*true') -ne 0 ]
 }
+
+
+@test "reject deployment because privileged container" {
+  run kwctl run annotated-policy.wasm -r test_data/deployment_with_privileged_containers.json
+
+  # this prints the output when one the checks below fails
+  echo "output = ${output}"
+
+  # request rejected
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : '.*allowed.*false') -ne 0 ]
+  [ $(expr "$output" : '.*Privileged container is not allowed*') -ne 0 ]
+}
+
+@test "reject statefulset because privileged container" {
+  run kwctl run annotated-policy.wasm -r test_data/statefulset_with_privileged_container.json
+
+  # this prints the output when one the checks below fails
+  echo "output = ${output}"
+
+  # request rejected
+  [ "$status" -eq 0 ]
+  [ $(expr "$output" : '.*allowed.*false') -ne 0 ]
+  [ $(expr "$output" : '.*Privileged container is not allowed*') -ne 0 ]
+}

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,7 +1,7 @@
 rules:
   - apiGroups: [""]
     apiVersions: ["v1"]
-    resources: ["pods"]
+    resources: ["deployment","replicaset","statefulset","daemonset","replicationcontroller","job","cronjob","pod"]
     operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
 mutating: false
 contextAware: false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,10 @@ fn validate(payload: &[u8]) -> CallResult {
     let validation_request: ValidationRequest<Settings> = ValidationRequest::new(payload)?;
     info!(LOG_DRAIN, "starting validation");
 
-    match serde_json::from_value::<apicore::Pod>(validation_request.request.object) {
-        Ok(pod) => {
-            if let Some(pod_spec) = &pod.spec {
-                return match validate_pod(pod_spec) {
+    match validation_request.extract_pod_spec_from_object() {
+        Ok(pod_spec) => {
+            if let Some(pod_spec) = pod_spec {
+                return match validate_pod(&pod_spec) {
                     Ok(_) => kubewarden::accept_request(),
                     Err(err) => kubewarden::reject_request(Some(err.to_string()), None, None, None),
                 };

--- a/test_data/deployment_with_privileged_containers.json
+++ b/test_data/deployment_with_privileged_containers.json
@@ -1,0 +1,39 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "nginx",
+              "name": "nginx",
+              "securityContext": {
+                "privileged": true
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "Deployment"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}

--- a/test_data/statefulset_with_privileged_container.json
+++ b/test_data/statefulset_with_privileged_container.json
@@ -1,0 +1,39 @@
+{
+  "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+  "kind": {
+    "kind": "StatefulSet",
+    "version": "v1"
+  },
+  "object": {
+    "metadata": {
+      "name": "nginx"
+    },
+    "spec": {
+      "template": {
+        "spec": {
+          "containers": [
+            {
+              "image": "nginx",
+              "name": "nginx",
+              "securityContext": {
+                "privileged": true
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operation": "CREATE",
+  "requestKind": {
+    "version": "v1",
+    "kind": "StatefulSet"
+  },
+  "userInfo": {
+    "username": "alice",
+    "uid": "alice-uid",
+    "groups": [
+      "system:authenticated"
+    ]
+  }
+}


### PR DESCRIPTION
Updates the policy to verify high level resources instead of Pod. This way, the resource creation will be rejected instead of rejecting the Pod creating in the deployment phase.

Fix #33 
Depends on https://github.com/kubewarden/policy-sdk-rust/pull/62