### PR TITLE
fix: define correct rules

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -33,7 +33,15 @@ annotations:
         apiVersions: ["v1"]
         resources: ["pods"]
         operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["replicationcontrollers"]
+        operations: ["CREATE", "UPDATE"]
       - apiGroups: ["apps"]
         apiVersions: ["v1"]
-        resources: ["deployments","replicasets","statefulsets","daemonsets","replicationcontrollers","jobs","cronjobs"]
-        operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+        resources: ["deployments","replicasets","statefulsets","daemonsets"]
+        operations: ["CREATE", "UPDATE"]
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        resources: ["jobs","cronjobs"]
+        operations: ["CREATE", "UPDATE"]

--- a/metadata.yml
+++ b/metadata.yml
@@ -3,10 +3,18 @@ rules:
     apiVersions: ["v1"]
     resources: ["pods"]
     operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["replicationcontrollers"]
+    operations: ["CREATE", "UPDATE"]
   - apiGroups: ["apps"]
     apiVersions: ["v1"]
-    resources: ["deployments","replicasets","statefulsets","daemonsets","replicationcontrollers","jobs","cronjobs"]
-    operations: ["CREATE"] # kubernetes doesn't allow to add/remove privileged containers to an already running pod
+    resources: ["deployments","replicasets","statefulsets","daemonsets"]
+    operations: ["CREATE", "UPDATE"]
+  - apiGroups: ["batch"]
+    apiVersions: ["v1"]
+    resources: ["jobs","cronjobs"]
+    operations: ["CREATE", "UPDATE"]
 mutating: false
 contextAware: false
 annotations:


### PR DESCRIPTION
Specify the resources targetted by the policy using their correct api groups.

Also, higher level resources should be monitored also for `UPDATE` events.
