### PR TITLE
Bump v0.2.6 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pod-privileged-policy"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pod-privileged-policy"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["José Guilherme Vanz <jguilhermevanz@suse.com>"]
 edition = "2021"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.2.5
+version: 0.2.6
 name: pod-privileged-policy
 displayName: Pod Privileged Policy
-createdAt: 2023-03-21T11:39:45.702098839Z
+createdAt: 2023-07-07T16:33:19.153637178Z
 description: Limit the ability to create privileged containers
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/pod-privileged-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/pod-privileged:v0.2.5
+  image: ghcr.io/kubewarden/policies/pod-privileged:v0.2.6
 keywords:
 - psp
 - pod
@@ -21,13 +21,13 @@ keywords:
 - privileged
 links:
 - name: policy
-  url: https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.2.5/policy.wasm
+  url: https://github.com/kubewarden/pod-privileged-policy/releases/download/v0.2.6/policy.wasm
 - name: source
   url: https://github.com/kubewarden/pod-privileged-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/pod-privileged:v0.2.5
+  kwctl pull ghcr.io/kubewarden/policies/pod-privileged:v0.2.6
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and artifacthub files bumping the policy version to v0.2.6

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
