### PR TITLE
chore(deps): run lock file maintenance at any time.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
     "area/dependencies"
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": ["at any time"]
   },
   "rebaseWhen": "behind-base-branch",
   "automerge": true


### PR DESCRIPTION
## Description

Updates the renovate bot configuration to allow it to create lock file maintenance PR at any time. As we are auto merging the PR we do not need to wait to create the PR and leave renovate bot update the file as soon as possible.

