### PR TITLE
chore(deps): lock file maintenance once a week.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["at any time"]
+    "schedule": ["before 4am on monday"]
   },
   "rebaseWhen": "behind-base-branch",
   "automerge": true


### PR DESCRIPTION
## Description

Allowing lock file maintenance at any time is too much noise. Updates the renovate bot to run it once a week.

